### PR TITLE
Generalised S3 polling

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,8 +1,8 @@
 package cache
 
-import(
-	"github.com/creamdog/aproxy/cache/memcached"
-	"github.com/creamdog/aproxy/cache/elasticache"
+import (
+	"./elasticache"
+	"./memcached"
 	"fmt"
 )
 
@@ -13,23 +13,21 @@ type CacheClient interface {
 	FlushAll() error
 }
 
-
 func Get(config map[string]interface{}) (CacheClient, error) {
 	if t, exists := config["type"].(string); exists {
 		switch t {
-			case "memcached" :
-				return memcached.Init(config)
-			case "elasticache" :
-				return elasticache.Init(config)
-			default:
-				return nil, fmt.Errorf("unsupported cache type: %s", t)
-		}	
-	} 
+		case "memcached":
+			return memcached.Init(config)
+		case "elasticache":
+			return elasticache.Init(config)
+		default:
+			return nil, fmt.Errorf("unsupported cache type: %s", t)
+		}
+	}
 	return &NoopClient{}, nil
 }
 
 type NoopClient struct {
-
 }
 
 func (np *NoopClient) Get(key string, v interface{}) (bool, error) {

--- a/cache/elasticache/elasticache.go
+++ b/cache/elasticache/elasticache.go
@@ -1,15 +1,15 @@
 package elasticache
 
-import(
-	"github.com/crowdmob/goamz/elasticache"
-	"github.com/crowdmob/goamz/aws"
-	"github.com/creamdog/aproxy/cache/memcached"
+import (
+	"../memcached"
 	"fmt"
+	"github.com/crowdmob/goamz/aws"
+	"github.com/crowdmob/goamz/elasticache"
 )
 
 func Init(config map[string]interface{}) (*memcached.MemcachedClient, error) {
 	auth := &aws.Auth{AccessKey: config["access_key"].(string), SecretKey: config["secret_key"].(string)}
-	client := elasticache.New(*auth, aws.GetRegion(config["region"].(string)))	
+	client := elasticache.New(*auth, aws.GetRegion(config["region"].(string)))
 	if info, err := client.DescribeCacheCluster(config["cluster"].(string)); err != nil {
 		return nil, err
 	} else {

--- a/config/config.go
+++ b/config/config.go
@@ -1,16 +1,16 @@
 package config
 
 import (
+	"../log"
 	"encoding/json"
 	"io/ioutil"
-	"github.com/creamdog/aproxy/log"
 )
 
 type Config struct {
 	Listeners   []map[string]interface{} `json:"listeners"`
 	Mappings    map[string]interface{}   `json:"mappings"`
 	MappingRepo map[string]interface{}   `json:"mapping"`
-	Cache 		map[string]interface{}   `json:"cache"`
+	Cache       map[string]interface{}   `json:"cache"`
 }
 
 func Load(filename string) (*Config, error) {

--- a/config/file/file.go
+++ b/config/file/file.go
@@ -1,8 +1,8 @@
 package file
 
 import (
+	"../../mappings"
 	"encoding/json"
-	"github.com/creamdog/aproxy/mappings"
 	"io/ioutil"
 	"log"
 	"path"

--- a/config/s3/s3.go
+++ b/config/s3/s3.go
@@ -7,30 +7,62 @@ import (
 	"github.com/crowdmob/goamz/s3"
 	"log"
 	"strings"
-	"time"
 )
 
-type worker struct {
-	auth          *aws.Auth
-	s3Client      *s3.S3
-	bucket        *s3.Bucket
-	mapping       *mappings.Mappings
-	enabledPrefix string
-	config        map[string]interface{}
-	seen          map[string]*ConfigStatus
-}
-
-type ConfigStatus struct {
-	ids      []string
-	modified string
+type FilesStatus struct {
+	Mappings         *mappings.Mappings
+	FileToMappingIds map[string][]string
 }
 
 func Start(mapping *mappings.Mappings, config map[string]interface{}) {
 	auth := &aws.Auth{AccessKey: config["access_key"].(string), SecretKey: config["secret_key"].(string)}
 	s3Client := s3.New(*auth, aws.GetRegion(config["region"].(string)))
 	bucket := s3Client.Bucket(config["bucket"].(string))
-	w := &worker{auth, s3Client, bucket, mapping, config["enabled_prefix"].(string), config, make(map[string]*ConfigStatus)}
-	go w.poll()
+
+	filesStatus := FilesStatus{mapping, make(map[string][]string)}
+
+	poller := S3Poller{
+		auth,
+		s3Client,
+		bucket,
+		config["enabled_prefix"].(string),
+		make(map[string]string),
+		filesStatus.makeAdditionHandler(),
+		filesStatus.makeRemovalHandler(),
+	}
+
+	go poller.poll()
+}
+
+func (fs *FilesStatus) makeAdditionHandler() func([]byte, s3.Key) error {
+	return func(data []byte, content s3.Key) error {
+		dconf := map[string]interface{}{}
+		if err := json.Unmarshal(data, &dconf); err != nil {
+			log.Printf("%s => %q", content.Key, err)
+			return err
+		}
+		dconf = ConfigMap(dconf).LowerCaseKeys()
+
+		log.Printf(string(data))
+		log.Printf("%q", dconf)
+
+		if ids, err := fs.Mappings.Register(dconf["mappings"].(map[string]interface{})); err != nil {
+			log.Printf("%q", err)
+			return err
+		} else {
+			fs.FileToMappingIds[content.Key] = ids
+			log.Printf("%s => registered ids %q", content.Key, fs.FileToMappingIds[content.Key])
+		}
+
+		return nil
+	}
+}
+
+func (fs *FilesStatus) makeRemovalHandler() func(string) error {
+	return func(key string) error {
+		fs.Mappings.DeRegister(fs.FileToMappingIds[key])
+		return nil
+	}
 }
 
 type ConfigMap map[string]interface{}
@@ -46,70 +78,4 @@ func (m ConfigMap) LowerCaseKeys() map[string]interface{} {
 		}
 	}
 	return tmp
-}
-
-func (w *worker) poll() {
-
-	for {
-		more := true
-		marker := ""
-		seen := make([]string, 0)
-		for more {
-			more = false
-			resp, err := w.bucket.List(w.enabledPrefix, "", marker, 1000)
-			if err != nil {
-				log.Printf("%q", err)
-				continue
-			}
-			for _, content := range resp.Contents {
-				seen = append(seen, content.Key)
-				if m, exist := w.seen[content.Key]; exist && m.modified == content.LastModified {
-					continue
-				}
-				w.seen[content.Key] = &ConfigStatus{make([]string, 0), content.LastModified}
-				log.Printf("fetching mapping configuration %s", content.Key)
-				data, err := w.bucket.Get(content.Key)
-				if err != nil {
-					log.Printf("%q", err)
-					continue
-				}
-				dconf := map[string]interface{}{}
-				if err = json.Unmarshal(data, &dconf); err != nil {
-					log.Printf("%s => %q", content.Key, err)
-					continue
-				}
-				dconf = ConfigMap(dconf).LowerCaseKeys()
-
-				log.Printf(string(data))
-				log.Printf("%q", dconf)
-
-				if ids, err := w.mapping.Register(dconf["mappings"].(map[string]interface{})); err != nil {
-					log.Printf("%q", err)
-					continue
-				} else {
-					w.seen[content.Key].ids = ids
-					log.Printf("%s => registered ids %q", content.Key, w.seen[content.Key].ids)
-				}
-			}
-			more = resp.IsTruncated
-			marker = resp.Marker
-		}
-
-		for key, _ := range w.seen {
-			found := false
-			for _, key2 := range seen {
-				if key == key2 {
-					found = true
-					break
-				}
-			}
-			if !found {
-				log.Printf("de-registering mappings %q", w.seen[key].ids)
-				w.mapping.DeRegister(w.seen[key].ids)
-				delete(w.seen, key)
-			}
-		}
-
-		time.Sleep(5 * time.Second)
-	}
 }

--- a/config/s3/s3.go
+++ b/config/s3/s3.go
@@ -1,8 +1,8 @@
 package s3
 
 import (
+	"../../mappings"
 	"encoding/json"
-	"github.com/creamdog/aproxy/mappings"
 	"github.com/crowdmob/goamz/aws"
 	"github.com/crowdmob/goamz/s3"
 	"log"

--- a/listener/listener.go
+++ b/listener/listener.go
@@ -1,7 +1,7 @@
 package listener
 
-import(
-	"github.com/creamdog/aproxy/listener/http"
+import (
+	"./http"
 	nethttp "net/http"
 )
 
@@ -11,8 +11,8 @@ type Listener interface {
 	IsRunning() bool
 }
 
-var Implementations = map[string]func(map[string]interface{}, func(map[string]interface{}, nethttp.ResponseWriter)) (Listener, error) {
-	"http" : func(config map[string]interface{}, ondata func(map[string]interface{}, nethttp.ResponseWriter)) (Listener, error) {
+var Implementations = map[string]func(map[string]interface{}, func(map[string]interface{}, nethttp.ResponseWriter)) (Listener, error){
+	"http": func(config map[string]interface{}, ondata func(map[string]interface{}, nethttp.ResponseWriter)) (Listener, error) {
 		return http.Init(config, ondata)
 	},
 }

--- a/main.go
+++ b/main.go
@@ -1,17 +1,17 @@
 package main
 
 import (
-	"github.com/creamdog/aproxy/config"
-	"github.com/creamdog/aproxy/config/file"
-	"github.com/creamdog/aproxy/config/s3"
-	"github.com/creamdog/aproxy/listener"
-	"github.com/creamdog/aproxy/mappings"
-	"github.com/creamdog/aproxy/cache"
-	httppipe "github.com/creamdog/aproxy/pipes/http"
+	"./cache"
+	"./config"
+	"./config/file"
+	"./config/s3"
+	"./listener"
+	"./mappings"
+	httppipe "./pipes/http"
 	//"log"
+	"./log"
 	"net/http"
-	"time"	
-	"github.com/creamdog/aproxy/log"
+	"time"
 )
 
 var mappingsCollection *mappings.Mappings

--- a/pipes/http/http.go
+++ b/pipes/http/http.go
@@ -1,11 +1,11 @@
 package http
 
 import (
+	"../../cache"
+	"../../mappings"
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/creamdog/aproxy/cache"
-	"github.com/creamdog/aproxy/mappings"
 	"io"
 	"log"
 	"net/http"


### PR DESCRIPTION
This enables the S3 polling to be reused by other projects (like go_achievements). Here, it should work exactly the same way as before. 

Also made import paths relative where possible. The important part lies in `config/s3/s3.go`, and the new file `config/s3/s3Poller.go`. 

Suggestions for making this better/cleaner are welcome. 
